### PR TITLE
Increase idle timeout for mysql imports.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -312,7 +312,7 @@ class Application extends ParentApplication {
    * @param $timeout
    * @param $idleTimeout
    */
-  public function runcommand($command, $io, $TTY = FALSE, $timeout = 3600, $idleTimeout = 60) {
+  public function runcommand($command, $io, $TTY = FALSE, $timeout = 3600, $idleTimeout = 600) {
 
     global $output;
     $output = $io;

--- a/src/Command/Mysql/MysqlImportCommand.php
+++ b/src/Command/Mysql/MysqlImportCommand.php
@@ -120,7 +120,7 @@ class MysqlImportCommand extends Command {
         // @todo resolve and update - https://github.com/docker/compose/issues/4290
         //$command = $container_application->getComposePath($appname, $io) . 'exec -T mysql mysql -u drudock -pMYSQLPASS drudock_db < ' . $importpath;
         $command = 'docker exec -i $(' . $container_application->getComposePath($appname, $io) . 'ps -q mysql) mysql -u drudock -pMYSQLPASS drudock_db < ' . $importpath;
-        $application->runcommand($command, $io, FALSE, 3600, 600);
+        $application->runcommand($command, $io);
       }
     }
     else {

--- a/src/Command/Mysql/MysqlImportCommand.php
+++ b/src/Command/Mysql/MysqlImportCommand.php
@@ -120,7 +120,7 @@ class MysqlImportCommand extends Command {
         // @todo resolve and update - https://github.com/docker/compose/issues/4290
         //$command = $container_application->getComposePath($appname, $io) . 'exec -T mysql mysql -u drudock -pMYSQLPASS drudock_db < ' . $importpath;
         $command = 'docker exec -i $(' . $container_application->getComposePath($appname, $io) . 'ps -q mysql) mysql -u drudock -pMYSQLPASS drudock_db < ' . $importpath;
-        $application->runcommand($command, $io);
+        $application->runcommand($command, $io, FALSE, 3600, 600);
       }
     }
     else {


### PR DESCRIPTION
My mysql imports were timing out which meant I couldn't import dbs. Increasing the idletimeout value of the process instance helped. Not sure if this should be even higher.